### PR TITLE
Added -a flag to shopify theme push

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -23,4 +23,4 @@ jobs:
           SHOPIFY_FLAG_STORE: ${{ secrets.SHOPIFY_STORE }}
           SHOPIFY_CLI_THEME_TOKEN: ${{ secrets.SHOPIFY_CLI_THEME_TOKEN }}
           SHOPIFY_CLI_TTY: 0
-        run: shopify theme push --theme ${{ secrets.SHOPIFY_THEME_ID }}
+        run: shopify theme push --theme ${{ secrets.SHOPIFY_THEME_ID }} -a


### PR DESCRIPTION
I'm not sure if you are still maintaining this repo, but I thought I would pass this along.
shopify theme push --theme *** requires confirmation when pushing to a live theme.
The -a flag allows pushing to a live theme.
